### PR TITLE
MARBLE-678 Create better primary key for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Marble User Content consists of an AWS API Gateway, three AWS DynamoDB tables an
 
 Use generated content consists of information about `Users`, user created `Collections`, and individual `Items` saved to those collections.
 
-`collectionId` and `itemId` are generated automatically on a successful `POST` request using `uuid` version 4. `userId` is a hash using information from the JWT, specifically it is formatted `[sub]`.`[btoa(iss)]` where `sub` is a guaranteed static unique id from the token issuer `iss`. Since `iss` is a url, it is base64 encoded to make parsing the hash less messy.
+`collectionId` and `itemId` are generated automatically on a successful `POST` request using `uuid` version 4. `userId` is a hash using information from the JWT, specifically it is formatted `[sub]`.`[btoa(iss)]` where `sub` is a guaranteed static unique value to identify a user within the scope of an issuer `iss`. `iss` is the url for the JWT issuer. Since it is a url, it has been base64 encoded to make the string simpler to parse should the need arise. (Simply split the string on `.` and `atob` the second part to get the url of the issuer again.)
 
 ### API Endpoints
 * `/user/{userId}`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Use generated content consists of information about `Users`, user created `Colle
   * `PATCH`
   * `DELETE`
 
+### Allowed fields on content types
+
+  See `/src/helpers/keys.js`.
+
 ## Installation
 
 Perform a yarn installation in the main project directory and also in the `src` directory.

--- a/README.md
+++ b/README.md
@@ -5,15 +5,21 @@ Marble User Content consists of an AWS API Gateway, three AWS DynamoDB tables an
 
 Use generated content consists of information about `Users`, user created `Collections`, and individual `Items` saved to those collections.
 
-### API Endpoints
-* `/user/{userName}`
-  * `POST`
-  * `GET`
-  * `PATCH`
+`collectionId` and `itemId` are generated automatically on a successful `POST` request using `uuid` version 4. `userId` is a hash using information from the JWT, specifically it is formatted `[sub]`.`[btoa(iss)]` where `sub` is a guaranteed static unique id from the token issuer `iss`. Since `iss` is a url, it is base64 encoded to make parsing the hash less messy.
 
+### API Endpoints
+* `/user/{userId}`
+  * `POST`
+  * `PATCH`
+  * `DELETE`
+* `/user/{userName}`
+  * `GET`
+
+* `/user-id/{userId}`
+  * `GET`
 
 * `/collection/{userName}`
-  * `POST`    
+  * `POST`
 * `/collection/{collectionId}`
   * `GET`
   * `PATCH`

--- a/src/helpers/errors.js
+++ b/src/helpers/errors.js
@@ -1,10 +1,11 @@
 module.exports = {
   DYNAMODB_EXECUTION_ERROR: 'Error: Execution update, caused a Dynamodb error, please take a look at your CloudWatch Logs.',
-  MISSING_FOREIGN_KEY: 'invalid request, you are missing a foreign key parameter',
-  MISSING_PARAMS_BODY: 'invalid request, you are missing the parameter body',
-  MISSING_PATH_ID: 'invalid request, you are missing the path parameter id',
-  NO_ARGS: 'invalid request, no arguments provided',
-  NOT_FOUND: 'the requested item could not be found',
+  MISSING_FOREIGN_KEY: 'Error: invalid request, you are missing a foreign key parameter',
+  MISSING_PARAMS_BODY: 'Error: invalid request, you are missing the parameter body',
+  MISSING_PATH_ID: 'Error: invalid request, you are missing the path parameter id',
+  NO_ARGS: 'Error: invalid request, no arguments provided',
+  NOT_FOUND: 'Error: the requested item could not be found',
   RESERVED_RESPONSE: 'Error: AWS reserved keywords used as attributes',
-  UNAUTHORIZED: 'missing or invalid authorization token for this action',
+  UNAUTHORIZED: 'Error: missing or invalid authorization token for this action',
+  UNKNOWN_REQUEST: 'Error: invalid request, unknown request',
 }

--- a/src/helpers/get.js
+++ b/src/helpers/get.js
@@ -3,6 +3,7 @@ const AWS = require('aws-sdk')
 const db = new AWS.DynamoDB.DocumentClient()
 const errors = require('./errors')
 const headers = require('./headers')
+const USER_TABLE_NAME = process.env.USER_TABLE_NAME || 'marble-user-content-users'
 
 module.exports.get = async ({ id, table, primaryKey, secondaryKey, secondaryId, childrenName, childTable, childSecondaryKey }) => {
   if (!id) {
@@ -14,7 +15,7 @@ module.exports.get = async ({ id, table, primaryKey, secondaryKey, secondaryId, 
       [primaryKey]: id,
     },
   }
-  if (secondaryKey) {
+  if (secondaryKey && table === USER_TABLE_NAME) {
     params = {
       TableName: table,
       IndexName: secondaryKey,

--- a/src/helpers/keys.js
+++ b/src/helpers/keys.js
@@ -2,6 +2,7 @@
 module.exports = {
   user:[
     'name',
+    'userName',
     'email',
     'bio',
   ],

--- a/src/helpers/keys.js
+++ b/src/helpers/keys.js
@@ -1,7 +1,7 @@
 'use strict'
 module.exports = {
   user:[
-    'name',
+    'fullName',
     'userName',
     'email',
     'bio',

--- a/src/helpers/update.js
+++ b/src/helpers/update.js
@@ -61,7 +61,7 @@ module.exports.update = async ({ id, table, primaryKey, allowedKeys, body }) => 
     })
   } catch (dbError) {
     const errorResponse = dbError.code === 'ValidationException' && dbError.message.includes('reserved keyword')
-      ? errors.DYNAMODB_EXECUTION_ERROR : errors.RESERVED_RESPONSEE
+      ? errors.DYNAMODB_EXECUTION_ERROR : errors.RESERVED_RESPONSE
     return {
       statusCode: 500,
       headers: headers,

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -1,4 +1,5 @@
 'use strict'
+const btoa = require('btoa')
 const uuidv4 = require('uuid/v4')
 const authorizer = require('./helpers/authorizer')
 const createHelper = require('./helpers/create')
@@ -9,14 +10,14 @@ const allowedKeys = require('./helpers/keys')
 const errors = require('./helpers/errors')
 const headers = require('./helpers/headers')
 const USER_TABLE_NAME = process.env.USER_TABLE_NAME || 'marble-user-content-users'
-const USER_PRIMARY_KEY = process.env.USER_PRIMARY_KEY || 'userName'
+const USER_PRIMARY_KEY = process.env.USER_PRIMARY_KEY || 'uuid'
+const USER_SECONDARY_KEY = process.env.USER_SECONDARY_KEY || 'userName'
 const COLLECTION_TABLE_NAME = process.env.COLLECTION_TABLE_NAME || 'marble-user-content-collections'
 const COLLECTION_PRIMARY_KEY = process.env.COLLECTION_PRIMARY_KEY || 'uuid'
-const COLLECTION_SECONDARY_KEY = process.env.COLLECTION_SECONDARY_KEY || 'userName'
+const COLLECTION_SECONDARY_KEY = process.env.COLLECTION_SECONDARY_KEY || 'userId'
 const ITEM_TABLE_NAME = process.env.ITEM_TABLE_NAME || 'marble-user-content-items'
 const ITEM_PRIMARY_KEY = process.env.ITEM_PRIMARY_KEY || 'uuid'
-const ITEM_SECONDARY_KEY = process.env.ITEM_SECONDARY_KEY || 'collection'
-const USERNAME_CLAIM = process.env.USERNAME_CLAIM || 'netid'
+const ITEM_SECONDARY_KEY = process.env.ITEM_SECONDARY_KEY || 'collectionId'
 
 module.exports.handler = async (event) => {
   const props = await requestProps(event)
@@ -47,8 +48,17 @@ module.exports.handler = async (event) => {
       return deleteHelper.delete(props)
 
     case 'GET':
-    default:
+      if (event.resource.indexOf('user') === 1 && event.resource.indexOf('user-id') !== 1) {
+        props.secondaryId = props.id
+        props.secondaryKey = USER_SECONDARY_KEY
+      }
       return getHelper.get(props)
+    default:
+      return {
+        statusCode: 500,
+        headers: headers,
+        body: errors.UNKNOWN_REQUEST,
+      }
   }
 }
 
@@ -70,7 +80,6 @@ const requestProps = async (event) => {
   } else if (event.resource.indexOf('collection') === 1) {
     props.table = COLLECTION_TABLE_NAME
     props.primaryKey = COLLECTION_PRIMARY_KEY
-    props.secondaryKey = COLLECTION_SECONDARY_KEY
     props.allowedKeys = allowedKeys.collection
     props.childrenName = 'items'
     props.childTable = ITEM_TABLE_NAME
@@ -79,7 +88,6 @@ const requestProps = async (event) => {
   } else if (event.resource.indexOf('item') === 1) {
     props.table = ITEM_TABLE_NAME
     props.primaryKey = ITEM_PRIMARY_KEY
-    props.secondaryKey = ITEM_SECONDARY_KEY
     props.allowedKeys = allowedKeys.item
   }
 
@@ -87,13 +95,13 @@ const requestProps = async (event) => {
 }
 
 const canModify = async (event, claims) => {
-  if (claims[USERNAME_CLAIM]) {
+  if (userIdFromClaims(claims)) {
     if (event.resource.indexOf('user') === 1) {
       // users cannot currently be deleted
       if (event.httpMethod === 'DELETE') {
         return false
       }
-      return claims[USERNAME_CLAIM] === event.pathParameters.id
+      return userIdFromClaims(claims) === event.pathParameters.id
     } else if (event.resource.indexOf('collection') === 1) {
       // valid users can create new collections, but ownership must be checked before modify or delete
       if (event.httpMethod === 'POST') {
@@ -104,7 +112,7 @@ const canModify = async (event, claims) => {
         table: COLLECTION_TABLE_NAME,
         primaryKey: COLLECTION_PRIMARY_KEY,
       })
-      return collection.statusCode === 200 && JSON.parse(collection.body)[COLLECTION_SECONDARY_KEY] === claims[USERNAME_CLAIM]
+      return collection.statusCode === 200 && JSON.parse(collection.body)[COLLECTION_SECONDARY_KEY] === userIdFromClaims(claims)
     } else if (event.resource.indexOf('item') === 1) {
       // items must have a parent collection and user must match
 
@@ -114,7 +122,7 @@ const canModify = async (event, claims) => {
           table: COLLECTION_TABLE_NAME,
           primaryKey: COLLECTION_PRIMARY_KEY,
         })
-        return parentCollection.statusCode === 200 && JSON.parse(parentCollection.body)[COLLECTION_SECONDARY_KEY] === claims[USERNAME_CLAIM]
+        return parentCollection.statusCode === 200 && JSON.parse(parentCollection.body)[COLLECTION_SECONDARY_KEY] === userIdFromClaims(claims)
       }
       // get item then get collection    }
       const item = await getHelper.get({
@@ -129,9 +137,17 @@ const canModify = async (event, claims) => {
           table: COLLECTION_TABLE_NAME,
           primaryKey: COLLECTION_PRIMARY_KEY,
         })
-        return collection.statusCode === 200 && JSON.parse(collection.body)[COLLECTION_SECONDARY_KEY] === claims[USERNAME_CLAIM]
+        return collection.statusCode === 200 && JSON.parse(collection.body)[COLLECTION_SECONDARY_KEY] === userIdFromClaims(claims)
       }
     }
   }
   return false
+}
+
+const userIdFromClaims = (claims) => {
+  const { iss, sub } = claims
+  if (!iss || !sub) {
+    return null
+  }
+  return `${sub}.${btoa(iss)}`
 }

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -80,6 +80,7 @@ const requestProps = async (event) => {
   } else if (event.resource.indexOf('collection') === 1) {
     props.table = COLLECTION_TABLE_NAME
     props.primaryKey = COLLECTION_PRIMARY_KEY
+    props.secondaryKey = COLLECTION_SECONDARY_KEY
     props.allowedKeys = allowedKeys.collection
     props.childrenName = 'items'
     props.childTable = ITEM_TABLE_NAME
@@ -88,6 +89,7 @@ const requestProps = async (event) => {
   } else if (event.resource.indexOf('item') === 1) {
     props.table = ITEM_TABLE_NAME
     props.primaryKey = ITEM_PRIMARY_KEY
+    props.secondaryKey = ITEM_SECONDARY_KEY
     props.allowedKeys = allowedKeys.item
   }
 

--- a/src/package.json
+++ b/src/package.json
@@ -8,6 +8,7 @@
   "keywords": [],
   "dependencies": {
     "@okta/jwt-verifier": "^1.0.0",
+    "btoa": "^1.2.1",
     "uuid": "^3.3.3"
   }
 }

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -130,6 +130,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+btoa@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
+  integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"


### PR DESCRIPTION
Using `netid` as the primary key on the user table and the foreign key on the collection table will become problematic when we add in alternative forms of authentication (Facebook, Google, Microsoft). Although adding alternative logins is most likely not going to happen until post-beta, I felt it was better to address this now before having to deal with the potential for data migration and the needed changes to the front end code to follow the proper login steps. The following changes were made:

* The primary key of the user table has been changed to a hash `[sub]`.`[btoa(iss)]` where both `sub` and `iss` come from the claims in a properly formatted OpenId JWT. `sub` is a guaranteed static unique value to identify a user within the scope of the issuer, `iss`. `iss` is the url for the JWT issuer. Since it is a url, I've opted to base64 encode it to make the string simpler to parse should the need arise. (Simply split the string on `.` and `atob` the second part to get the url of the issuer again.)
* `POST`, `PATCH`, and `DELETE` request should now be to `/user/{userId}` as described above instead of `/user/{userName}`.
* A `GET` request to`/user/{username}` will continue to return the user.
* A new endpoint to get the user from the id has been added, `GET` to `/user-id/{user-id}`. This is likely to only be needed during the login stages on the MARBLE website when the username is not guaranteed to be known from the OpenId JWT.

Related Marble Blueprints change: https://github.com/ndlib/marble-blueprints/pull/130