### PR TITLE
MARBLE-808 Fix 401 errors

### DIFF
--- a/src/helpers/create.js
+++ b/src/helpers/create.js
@@ -5,6 +5,7 @@ const getHelper = require('./get')
 // const updateHelper = require('./update')
 const errors = require('./errors')
 const headers = require('./headers')
+const safeNull = require('./safeNull')
 
 module.exports.create = async ({ id, parentId, table, primaryKey, secondaryKey, allowedKeys, body }) => {
   if (!body) {
@@ -25,11 +26,13 @@ module.exports.create = async ({ id, parentId, table, primaryKey, secondaryKey, 
   // TODO: Verify object does not already exist
 
   const item = typeof body === 'object' ? body : JSON.parse(body)
-  // Removed non-allowed keys
+  // Removed non-allowed keys and sanitize nulls
   const properties = Object.keys(item)
   properties.forEach(property => {
     if (!allowedKeys.includes(property)) {
       delete item[property]
+    } else if (item[property] === '' || item[property] === null) {
+      item[property] = safeNull
     }
   })
   item[primaryKey] = id

--- a/src/helpers/get.js
+++ b/src/helpers/get.js
@@ -3,6 +3,7 @@ const AWS = require('aws-sdk')
 const db = new AWS.DynamoDB.DocumentClient()
 const errors = require('./errors')
 const headers = require('./headers')
+const safeNull = require('./safeNull')
 const USER_TABLE_NAME = process.env.USER_TABLE_NAME || 'marble-user-content-users'
 
 module.exports.get = async ({ id, table, primaryKey, secondaryKey, secondaryId, childrenName, childTable, childSecondaryKey }) => {
@@ -57,7 +58,7 @@ const getItem = async (params) => {
         return {
           statusCode: 200,
           headers: headers,
-          body: JSON.stringify(response.Item),
+          body: JSON.stringify(response.Item).replace(new RegExp(safeNull, 'g'), ''),
         }
       }
     } else if (params.KeyConditionExpression) {
@@ -66,7 +67,7 @@ const getItem = async (params) => {
         return {
           statusCode: 200,
           headers: headers,
-          body: JSON.stringify(response.Items[0]),
+          body: JSON.stringify(response.Items[0]).replace(new RegExp(safeNull, 'g'), ''),
         }
       }
     }
@@ -107,7 +108,7 @@ const getItemWithChildren = async (params, childParams, childrenName, childSecon
       return {
         statusCode: 200,
         headers: headers,
-        body: JSON.stringify(result),
+        body: JSON.stringify(result).replace(new RegExp(safeNull, 'g'), ''),
       }
     }
 

--- a/src/helpers/safeNull.js
+++ b/src/helpers/safeNull.js
@@ -1,0 +1,1 @@
+module.exports = '{{NULL}}'

--- a/src/helpers/update.js
+++ b/src/helpers/update.js
@@ -4,6 +4,7 @@ const db = new AWS.DynamoDB.DocumentClient()
 const getHelper = require('./get')
 const errors = require('./errors')
 const headers = require('./headers')
+const safeNull = require('./safeNull')
 module.exports.update = async ({ id, table, primaryKey, allowedKeys, body }) => {
   if (!body) {
     return { statusCode: 400,
@@ -31,6 +32,12 @@ module.exports.update = async ({ id, table, primaryKey, allowedKeys, body }) => 
     }
   }
 
+  // clean up null values
+  editedItemProperties.forEach(property => {
+    if (editedItem[property] === '' || editedItem[property] === null) {
+      editedItem[property] = safeNull
+    }
+  })
   // add updated time
   editedItem.updated = Date.now()
   editedItemProperties.push('updated')


### PR DESCRIPTION
DynamoDB cannot store empty strings. Sending a null value creates a null type field instead of a string field. To accommodate the possibility of users adding text to a previously empty field or removing all text from a previously valid string field, we're replacing empty strings and nulls 
with a hash value that is stored in the field on CREATE and UPDATE requests and then returned as an empty string on GET requests.