### PR TITLE
MARBLE-1034 Allow sort order

### DIFF
--- a/src/helpers/keys.js
+++ b/src/helpers/keys.js
@@ -18,7 +18,7 @@ module.exports = {
     'image',
     'link',
     'manifest',
-    'index',
+    'displayOrder',
     'annotation',
   ],
 }


### PR DESCRIPTION
* `index` is a special word for DynamoDB, so we need to switch this to 
something else so we don't get an error back when we try to set this as a key/value pair. Let's use `displayOrder`